### PR TITLE
feat: added build dir to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "build"
   ],
   "scripts": {
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
added build dir to package
build dir is already generated by `truffle compile` which is called during `npm run build` so no need to add any additional build steps