### PR TITLE
fix: 🐛 corrected surrender behaviour for title escrow owner

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -2,7 +2,7 @@ import {WrappedDocument} from "@govtechsg/open-attestation";
 import {providers, Wallet, Contract} from "ethers";
 import {getBatchMerkleRoot} from "./util/token";
 import {abi as TokenRegistryABI} from "../build/contracts/TradeTrustERC721.json";
-import {EthereumAddress} from "./types";
+import {EthereumAddress, EthereumTransactionHash} from "./types";
 import {waitForTransaction} from "./util/transaction";
 
 export class TokenRegistry {
@@ -46,7 +46,7 @@ export class TokenRegistry {
     return this.contractInstance.ownerOf(tokenId);
   }
 
-  async transferTo(document: WrappedDocument, newOwnerAddress: EthereumAddress) {
+  async transferTo(document: WrappedDocument, newOwnerAddress: EthereumAddress): Promise<EthereumTransactionHash> {
     const tokenId = getBatchMerkleRoot(document);
     const currentOwner = await this.ownerOf(document);
     return waitForTransaction(

--- a/src/token.ts
+++ b/src/token.ts
@@ -2,7 +2,7 @@ import {WrappedDocument} from "@govtechsg/open-attestation";
 import {getDefaultProvider, providers, Wallet} from "ethers";
 import {getIssuer} from "./util/token";
 import {TokenRegistry} from "./registry";
-import {EthereumAddress, EthereumNetwork} from "./types";
+import {EthereumAddress, EthereumNetwork, EthereumTransactionHash} from "./types";
 import {getWeb3Provider, getWallet} from "./provider";
 import {createOwner, Owner, TitleEscrowOwner, WriteableTitleEscrowOwner} from "./owner";
 
@@ -75,7 +75,11 @@ export class WriteableToken extends ReadOnlyToken {
     return this.tokenRegistry.transferTo(this.document, to);
   }
 
-  async surrender() {
+  async surrender(): Promise<EthereumTransactionHash> {
+    const tokenOwner = await this.getOwner();
+    if (tokenOwner instanceof WriteableTitleEscrowOwner) {
+      return tokenOwner.transferTo(this.tokenRegistry.address);
+    }
     return this.tokenRegistry.transferTo(this.document, this.tokenRegistry.address);
   }
 }


### PR DESCRIPTION
Previous implementation of surrender only worked for owners which were
EOAs, surrendering a token owned by a TitleEscrow requires the
transaction to originate from the TitleEscrow contract instead